### PR TITLE
Revert "feat: remove viewer request for cloudfront"

### DIFF
--- a/website/website.ts
+++ b/website/website.ts
@@ -190,6 +190,11 @@ export class WebSite extends pulumi.ComponentResource {
 
           lambdaFunctionAssociations: [
             {
+              eventType: "viewer-request",
+              lambdaArn: args.viewerRequestLambdaArn,
+              includeBody: false,
+            },
+            {
               eventType: "origin-request",
               lambdaArn: args.originRequestLambdaArn,
               includeBody: false,


### PR DESCRIPTION
This reverts commit 6212be3b9496e497f06eee8d5ba5b3d1f50960a6.

On Viewer Request could get the host viewer requested, but on origin request the host is S3.
And should never redirect to S3.